### PR TITLE
Fix the error on start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -144,6 +144,7 @@ fi
 if [ "$?" != 0 ]; then
     echo "Unable to connect to update website (internet connection may be down).  Skipping update ..."
 else
+    Build=$(curl -s -L "https://fill.papermc.io/v3/projects/paper/versions/$Version" | jq -r '.builds[0]' 2>/dev/null)
     if [[ -n "$Build" && "$Build" != "null" ]]; then
         echo "Latest paperclip build found: $Build"
         # Get the SHA256 hash and filename for the download URL (pipe directly to avoid newline issues in commit messages)


### PR DESCRIPTION
Add the missing argument for Build in the start.sh, causing broken the paper server files download and the message warning "Unable to retrieve latest Paper build (got result of $Build)"